### PR TITLE
69 fix stats styling PR

### DIFF
--- a/src/components/keyStats.tsx
+++ b/src/components/keyStats.tsx
@@ -14,8 +14,9 @@ const PlayAudio: React.FC<PA_Props> = ({ toggleAudioPlayer }) => {
       <Button onClick={toggleAudioPlayer} className={styles.audioButton}>
         <FaPlay className={styles.audioIcon} />
       </Button>
-
-      <span className={styles.paText}>Play Audio</span>
+      <div className={styles.vertCenter}>
+        <span className={styles.paText}>Play Audio</span>
+      </div>
     </div>
   );
 };
@@ -27,7 +28,9 @@ const AudioDuration: React.FC<AD_Props> = ({ duration }) => {
   return (
     <div className={styles.section}>
       <span className={styles.audioDuration}>{duration}</span>
-      <span className={styles.adText}>Audio Duration</span>
+      <div className={styles.vertCenter}>
+        <span className={styles.adText}>Audio Duration</span>
+      </div>
     </div>
   );
 };
@@ -55,7 +58,9 @@ const TourProgress: React.FC<TP_Props> = ({ tour_progress, total_tours }) => {
           {tour_progress}/{total_tours}
         </div>
       </div>
-      <span className={styles.tpText}>Tour Progress</span>
+      <div className={styles.vertCenter}>
+        <span className={styles.tpText}>Tour Progress</span>
+      </div>
     </div>
   );
 };

--- a/src/styles/keyStats.module.css
+++ b/src/styles/keyStats.module.css
@@ -26,7 +26,6 @@
 .tpText {
   font-size: 1.25rem;
   font-weight: 500;
-  min-height: 24px; /* same height for all to align */
   text-align: center;
   display: flex;
   align-items: flex-end;
@@ -34,8 +33,16 @@
   color: black;
   max-height: 60px;
   min-height: 50px;
+  margin: 0;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  -ms-transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%);
 }
-
+.vertCenter {
+  position: relative;
+}
 /* .paText {
   font-size: 1.25rem;
   font-weight: 500;

--- a/src/styles/keyStats.module.css
+++ b/src/styles/keyStats.module.css
@@ -33,6 +33,8 @@
   color: black;
   max-height: 60px;
   min-height: 50px;
+  /* this makes sure that its centered in the middle of the div i think*/
+
   margin: 0;
   position: absolute;
   top: 50%;
@@ -43,28 +45,6 @@
 .vertCenter {
   position: relative;
 }
-/* .paText {
-  font-size: 1.25rem;
-  font-weight: 500;
-  text-align: center;
-  color: black;
-  padding-top: 25px;
-}
-
-.adText {
-  font-size: 1.25rem;
-  font-weight: 500;
-  text-align: center;
-  color: black;
-  padding-top: 25px;
-}
-
-.tpText {
-  font-size: 1.25rem;
-  font-weight: 500;
-  text-align: center;
-  color: black;
-} */
 
 .sideContainer,
 .centerContainer {

--- a/src/styles/keyStats.module.css
+++ b/src/styles/keyStats.module.css
@@ -1,8 +1,6 @@
 .container {
   display: flex;
   width: 100vw;
-  max-height: fit-content;
-  min-height: fit-content;
 }
 
 .section {
@@ -34,6 +32,8 @@
   align-items: flex-end;
   /* justify-content: center; */
   color: black;
+  max-height: 60px;
+  min-height: 50px;
 }
 
 /* .paText {
@@ -72,6 +72,8 @@
 .progressContainer,
 .audioDuration {
   margin-bottom: 0.5rem; /* Push down space for text */
+  max-height: 100px;
+  min-height: 92px;
 }
 
 .audioDuration {

--- a/src/styles/keyStats.module.css
+++ b/src/styles/keyStats.module.css
@@ -1,12 +1,15 @@
 .container {
   display: flex;
   width: 100vw;
+  max-height: fit-content;
+  min-height: fit-content;
 }
+
 .section {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: space-around;
   background-color: #eeebe6;
   padding: 1.5rem;
   height: 100%; /* Ensure equal height */
@@ -20,28 +23,25 @@
   margin-top: 25px;
 }
 
-.paText {
+.paText,
+.adText,
+.tpText {
+  font-size: 1.25rem;
+  font-weight: 500;
+  min-height: 24px; /* same height for all to align */
+  text-align: center;
+  display: flex;
+  align-items: flex-end;
+  /* justify-content: center; */
+  color: black;
+}
+
+/* .paText {
   font-size: 1.25rem;
   font-weight: 500;
   text-align: center;
   color: black;
   padding-top: 25px;
-}
-
-.sideContainer,
-.centerContainer {
-  flex: 1; /* Ensure equal widths */
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.sideContainer,
-.centerContainer {
-  flex: 1; /* Ensure equal widths */
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 
 .adText {
@@ -57,6 +57,21 @@
   font-weight: 500;
   text-align: center;
   color: black;
+} */
+
+.sideContainer,
+.centerContainer {
+  flex: 1; /* Ensure equal widths */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Ensure icons and visual elements align properly */
+.audioButton,
+.progressContainer,
+.audioDuration {
+  margin-bottom: 0.5rem; /* Push down space for text */
 }
 
 .audioDuration {


### PR DESCRIPTION
## Developer: Jason Yu, Taiki Jeffers

Closes #69 

### Pull Request Summary
made it so that all labels and icons are level
### Modifications
- flex was turned to space arround
- made it so that all icons and text have min height of the largest icon and text respectively 
- created div for just text to center it within that text



{list out the files created/modified and a brief description of what was changed}

### Testing Considerations
- do more resizing tests
- all text heights are all the same, could do more in depth tests to make sure they're aligned (like comparing pixel levels)
{list out what you have tested and what the reviewer should verify}

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast
<img width="724" alt="image" src="https://github.com/user-attachments/assets/fa22800a-8f8b-44ce-8cd3-01d25950346f" />
Normal I phone size 
<img width="1111" alt="image" src="https://github.com/user-attachments/assets/945bf943-b3fc-4416-a327-7b1176482ac0" />
More obscure size, shows that text stays aligned and in 2 lines
{put screenshots of your change, or even better a screencast displaying the functionality}
