### PR TITLE
add feature to change status of poi when clicked

### DIFF
--- a/src/app/poi/page.tsx
+++ b/src/app/poi/page.tsx
@@ -16,6 +16,7 @@ function POIDetailContent() {
   const progress = parseInt(searchParams.get("progress") || "0", 10);
   const totalPois = parseInt(searchParams.get("totalCards") || "0", 10);
   const audioUrl = searchParams.get("audioField");
+  const poiID = searchParams.get("pid");
   return (
     <div>
       <Selected_POI_Page
@@ -26,6 +27,7 @@ function POIDetailContent() {
         duration={duration || "0:00"}
         tour_progress={progress}
         total_tours={totalPois}
+        id={poiID || ""}
       />
     </div>
   );

--- a/src/components/poiList.tsx
+++ b/src/components/poiList.tsx
@@ -113,6 +113,7 @@ export default function POICardList() {
                   progress: cardsDone,
                   totalCards: data.length,
                   audioField: POI.audioField,
+                  pid: POI._id,
                 },
               }}
             >

--- a/src/components/selectedPoi.tsx
+++ b/src/components/selectedPoi.tsx
@@ -28,6 +28,18 @@ interface POIProps {
   duration: string;
   tour_progress: number;
   total_tours: number;
+  id: string;
+}
+
+//For sessionStorage; to update isComplete
+interface POI {
+  _id: string;
+  name: string;
+  description: string;
+  audioField: string;
+  duration: string;
+  image: string;
+  isComplete: boolean;
 }
 
 const Selected_POI_Page: React.FC<POIProps> = ({
@@ -38,12 +50,41 @@ const Selected_POI_Page: React.FC<POIProps> = ({
   duration,
   tour_progress,
   total_tours,
+  id,
 }) => {
   const [isAudioVisible, setIsAudioVisible] = useState(false);
 
   const toggleAudioPlayer = () => {
     setIsAudioVisible((prev) => !prev);
   };
+
+  const [newTourProgress, updateTourProgress] = useState(tour_progress);
+
+  //When a card is selected, it should be marked as done in sessionStorage
+  try {
+    //Get locally stored data
+    const storedData = sessionStorage.getItem("poiData");
+
+    if (storedData) {
+      const data: POI[] = JSON.parse(storedData);
+
+      //Update tour progression and local data, if required
+      const updatedData = data.map((item) => {
+        if (item._id === id && !item.isComplete) {
+          updateTourProgress(tour_progress + 1);
+          return { ...item, isComplete: true };
+        } else {
+          return item;
+        }
+      });
+
+      //Save updated local data
+      sessionStorage.setItem("poiData", JSON.stringify(updatedData));
+    }
+  } catch (error) {
+    console.log("Error Updating Progress:", error);
+  }
+
   return (
     <div className={styles.pageContainer}>
       <div className={styles.mainImageContainer}>
@@ -56,7 +97,7 @@ const Selected_POI_Page: React.FC<POIProps> = ({
           <KeyStats
             audio_link={audio_link}
             duration={duration}
-            tour_progress={tour_progress}
+            tour_progress={newTourProgress}
             total_tours={total_tours}
             toggleAudioPlayer={toggleAudioPlayer}
           />


### PR DESCRIPTION
## Developer: Saurish Suman, Nick Carboni

Closes #67

### Pull Request Summary

Updates total visited places when clicked on a new POI.

### Modifications

selectedPOI.tsx - checks if this POI was visited before, if not updates the session storage and marks it as completed.
poi/page.tsx - added one more search parameter "pid", which keeps track of the ID of the POI.
poiList.tsx - updated to account for the new parameter (pid).

### Testing Considerations

{list out what you have tested and what the reviewer should verify}

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

{put screenshots of your change, or even better a screencast displaying the functionality}
